### PR TITLE
implemented fixed size block header & various reworks/corrections/opt…

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -29,7 +29,7 @@ extern const std::string CURRENCY_UNIT;
  *
  * In FairCoin2 this is the exact amount of balances from the FairCoin1 block chain
  * */
-static const CAmount MAX_MONEY = 5258950754947300;
+static const CAmount MAX_MONEY = 5293319405153800; // FairCoin1 block #341447
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 /** Type-safe wrapper class for fee rates

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -677,7 +677,8 @@ int main(int argc, char* argv[])
     return ret;
 }
 
-/* just a dummy */
-uint32_t CBlockHeader::GetNumChainSigs() const {
-    return vMissingSignerIds.size();
+// dummy
+uint32_t GetNumChainSigs(const CBlock *pblock)
+{
+    return 0;
 }

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -115,16 +115,9 @@ void CBlockIndex::BuildSkip()
 
 string CBlockIndex::ToString() const
 {
-    return strprintf("CBlockIndex(pprev=%p, nHeight=%d, pl=%s, nCreatorId=%08x, merkle=%s, hashBlock=%s, nTime=%u, nStatus=%08x, signatures=%u, adminSignatures=%u)",
+    return strprintf("CBlockIndex(pprev=%p, nHeight=%d, pl=%s, nCreatorId=%08x, merkle=%s, hashBlock=%s, nTime=%u, nStatus=%08x)",
         pprev, nHeight, GetPayloadString(), nCreatorId,
         hashMerkleRoot.ToString(),
         GetBlockHash().ToString(),
-        nTime, nStatus,
-        GetNumChainSigs(),
-        vAdminIds.size());
-}
-
-uint32_t CBlockIndex::GetNumChainSigs() const
-{
-    return mapCVNs.size() - vMissingCreatorIds.size();
+        nTime, nStatus);
 }

--- a/src/chain.h
+++ b/src/chain.h
@@ -144,11 +144,7 @@ public:
     unsigned int nTime;
     unsigned int nCreatorId;
 
-    CSchnorrSig chainMultiSig;
-    std::vector<uint32_t> vMissingCreatorIds;
-
-    CSchnorrSig adminMultiSig;
-    std::vector<uint32_t> vAdminIds;
+    vector<uint32_t> vMissingSignerIds;
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId;
@@ -172,10 +168,6 @@ public:
         hashMerkleRoot = uint256();
         nTime          = 0;
         nCreatorId     = 0;
-        chainMultiSig.SetNull();
-        vMissingCreatorIds.clear();
-        adminMultiSig.SetNull();
-        vAdminIds.clear();
     }
 
     CBlockIndex()
@@ -183,7 +175,7 @@ public:
         SetNull();
     }
 
-    CBlockIndex(const CBlockHeader& block)
+    CBlockIndex(const CBlockHeader& block, const vector<uint32_t>* vMissingSignerIdsIn)
     {
         SetNull();
 
@@ -191,10 +183,10 @@ public:
         hashMerkleRoot     = block.hashMerkleRoot;
         nTime              = block.nTime;
         nCreatorId         = block.nCreatorId;
-        chainMultiSig      = block.chainMultiSig;
-        vMissingCreatorIds = block.vMissingSignerIds;
-        adminMultiSig      = block.adminMultiSig;
-        vAdminIds          = block.vAdminIds;
+        if (vMissingSignerIdsIn)
+            vMissingSignerIds = *vMissingSignerIdsIn;
+        else
+            vMissingSignerIds.clear();
     }
 
     CDiskBlockPos GetBlockPos() const {
@@ -224,12 +216,6 @@ public:
         block.hashMerkleRoot     = hashMerkleRoot;
         block.nTime              = nTime;
         block.nCreatorId         = nCreatorId;
-        block.chainMultiSig      = chainMultiSig;
-        block.vMissingSignerIds = vMissingCreatorIds;
-        if (nVersion & CBlock::ADMIN_PAYLOAD_MASK) {
-            block.adminMultiSig      = adminMultiSig;
-            block.vAdminIds          = vAdminIds;
-        }
         return block;
     }
 
@@ -305,8 +291,6 @@ public:
 
     string ToString() const;
 
-    uint32_t GetNumChainSigs() const;
-
     //! Efficiently find an ancestor of this block.
     CBlockIndex* GetAncestor(int height);
     const CBlockIndex* GetAncestor(int height) const;
@@ -349,12 +333,6 @@ public:
         READWRITE(hashMerkleRoot);
         READWRITE(nTime);
         READWRITE(nCreatorId);
-        READWRITE(chainMultiSig);
-        READWRITE(vMissingCreatorIds);
-        if (this->nVersion & CBlock::ADMIN_PAYLOAD_MASK) {
-            READWRITE(adminMultiSig);
-            READWRITE(vAdminIds);
-        }
     }
 
     uint256 GetBlockHash() const
@@ -365,12 +343,6 @@ public:
         block.hashMerkleRoot     = hashMerkleRoot;
         block.nTime              = nTime;
         block.nCreatorId         = nCreatorId;
-        block.vMissingSignerIds = vMissingCreatorIds;
-        block.chainMultiSig      = chainMultiSig;
-        if (this->nVersion & CBlock::ADMIN_PAYLOAD_MASK) {
-            block.vAdminIds          = vAdminIds;
-            block.adminMultiSig      = adminMultiSig;
-        }
         return block.GetHash();
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -22,7 +22,7 @@ CDynamicChainParams dynParams;
 
 #define SHOW_GENESIS_HASHES 0
 
-#define GENESIS_BLOCK_TIMESTAMP 1485425400
+#define GENESIS_BLOCK_TIMESTAMP 1486220009
 const char* genesisMessage = "FairCoin - the currency for a fair economy.";
 
 static CBlock CreateGenesisBlock(uint32_t nTime, uint32_t nCreatorId, const CDynamicChainParams& dynamicChainParams)
@@ -94,12 +94,12 @@ public:
         genesis.vChainAdmins.resize(1);
         genesis.vChainAdmins[0] = CChainAdmin(GENESIS_ADMIN_ID, 0, CSchnorrPubKeyDER("0495b3d6338fc20b93b28220782a7444f8061d7794c4ba906dc38ea4041298d74e47b4a3544470ee7e6e8872321b853ba98bd1c32ccff30eb8da6475605082bcf0"));
 
-        genesis.hashMerkleRoot = BlockMerkleRoot(genesis);
-
         genesis.chainMultiSig = CSchnorrSigS("14dc4f77f9d59ece2b3aa02cc4df99954d47fa2719be207d1b5010745aec419e451f01a8749cd16f22a727d0deba5110d2ce7e44ff86f0efdea58db4efdb92cd");
         genesis.vAdminIds.push_back(GENESIS_ADMIN_ID);
         genesis.adminMultiSig = CSchnorrSigS("9d9f0a52fbe8db6e0751f2cca3d70e21f4268251104d62de4df1920aac7749215721072b20b692a79eafbc6ec943d1fea418991f49a51a7aa0bdc6d0f90d9d98");
-        genesis.creatorSignature = CSchnorrSigS("2e56d94212756c1341bfadb6b7c9dcbaef7cf8e54217b015352df5284f7804d2337855ec93c0d2d82fad3b315b93097d484031a52809e517f28d486b19b64970");
+        genesis.creatorSignature = CSchnorrSigS("9fbcc20819a74f2bf2c7e7022f22751101377bb06a629b258fd185b8b8490eca8aece2b1a29f6d22ec272f22bbaa7a516c946d64b5796d736e2aa40c69d636b9");
+
+        genesis.hashMerkleRoot = BlockMerkleRoot(genesis);
 
         consensus.hashGenesisBlock = genesis.GetHash();
 #if SHOW_GENESIS_HASHES
@@ -107,8 +107,8 @@ public:
                 consensus.hashGenesisBlock.ToString().c_str(),
                 genesis.hashMerkleRoot.ToString().c_str());
 #else
-        assert(consensus.hashGenesisBlock == uint256S("6c1ca4690844c8d21cc7223169838123c530803542fb807fb671f10e4b83ef97"));
-        assert(genesis.hashMerkleRoot == uint256S("7c27ade2c28e67ed3077f8f77b8ea6d36d4f5eba04c099be3c9faa9a4a04c046"));
+        assert(consensus.hashGenesisBlock == uint256S("1e3387e6ef91499b19d77491198348c3f930bde2139c91457ba0658a784bbe1f"));
+        assert(genesis.hashMerkleRoot == uint256S("e88b42f7f8f92db7447f92719842c910c750a842f2867d4be236882493267d62"));
 #endif
         vSeeds.push_back(CDNSSeedData("1.fair-coin.org", "faircoin2-seed1.fair-coin.org")); // Thomas König
         vSeeds.push_back(CDNSSeedData("2.fair-coin.org", "faircoin2-seed2.fair-coin.org")); // Thomas König
@@ -175,12 +175,12 @@ public:
         genesis.vChainAdmins.resize(1);
         genesis.vChainAdmins[0] = CChainAdmin(0xad000001, 0, CSchnorrPubKeyS("a1fe3aee6cd4b05d06cd7c686cf45a7820a9e28adb090e6576e8885f1013a829e1bbee64001b22d54825932e7602a04adf1e2511f765c6ab9792482b58063494"));
 
-        genesis.hashMerkleRoot = BlockMerkleRoot(genesis);
-
         genesis.chainMultiSig = CSchnorrSigS("a72fe573bb3ab202c7877cee3fab2ec7bbd733032536b6c2b8a0b9a48e61992da6442754414db30d82391224be7d0b596704a1b2baba4de8396ab340dd900b14");
         genesis.vAdminIds.push_back(GENESIS_ADMIN_ID);
         genesis.adminMultiSig = CSchnorrSigS("2980c1d39e75e0757b4288babc4322bb901f9b9962ba7958ebf58ec74e28ea58aca4830fa363ae104c3da1792e2bad170d6c6c6c1814d4d904902a5bbd7e96ff");
         genesis.creatorSignature = CSchnorrSigS("f35033d284b0a4ea164df9428597e801d216ffe64e43909d399388076bd2b5153f9f879e52fc78c38ebef13908387d430553fe71f5bbab5a2b62614f93b20134");
+
+        genesis.hashMerkleRoot = BlockMerkleRoot(genesis);
 
         consensus.hashGenesisBlock = genesis.GetHash();
 #if SHOW_GENESIS_HASHES
@@ -188,8 +188,8 @@ public:
                 consensus.hashGenesisBlock.ToString().c_str(),
                 genesis.hashMerkleRoot.ToString().c_str());
 #else
-        assert(consensus.hashGenesisBlock == uint256S("8ee63fe962a9576b379eab72a97261e9c08c2612500392220f677b222ab6d4da"));
-        assert(genesis.hashMerkleRoot == uint256S("7c27ade2c28e67ed3077f8f77b8ea6d36d4f5eba04c099be3c9faa9a4a04c046"));
+        assert(consensus.hashGenesisBlock == uint256S("687b117391a3f8d97784855e8bd32014424ded709de160ba2b0fb48f0f2af827"));
+        assert(genesis.hashMerkleRoot == uint256S("542573eb67965183b8025b5270ed865511b8b2437cd01c78a16fde34c97d026a"));
 #endif
         vFixedSeeds.clear();
         vSeeds.clear();
@@ -254,12 +254,12 @@ public:
         genesis.vCvns.resize(1);
         genesis.vCvns[0] = CCvnInfo(GENESIS_NODE_ID, 0, CSchnorrPubKeyS("f69bd29a5e2b8d0f5c185fcc421d11556c071788de07d3d194ded04721afaa652ad75a649a0dac8f576e484392af68f5c31ab0ef5e3432baf8b14b6ad8b1262c"));
 
-        genesis.hashMerkleRoot = BlockMerkleRoot(genesis);
-
         genesis.chainMultiSig = CSchnorrSigS("a72fe573bb3ab202c7877cee3fab2ec7bbd733032536b6c2b8a0b9a48e61992da6442754414db30d82391224be7d0b596704a1b2baba4de8396ab340dd900b14");
         genesis.vAdminIds.push_back(GENESIS_ADMIN_ID);
         genesis.adminMultiSig = CSchnorrSigS("2980c1d39e75e0757b4288babc4322bb901f9b9962ba7958ebf58ec74e28ea58aca4830fa363ae104c3da1792e2bad170d6c6c6c1814d4d904902a5bbd7e96ff");
         genesis.creatorSignature = CSchnorrSigS("f35033d284b0a4ea164df9428597e801d216ffe64e43909d399388076bd2b5153f9f879e52fc78c38ebef13908387d430553fe71f5bbab5a2b62614f93b20134");
+
+        genesis.hashMerkleRoot = BlockMerkleRoot(genesis);
 
         consensus.hashGenesisBlock = genesis.GetHash();
 #if SHOW_GENESIS_HASHES
@@ -267,8 +267,8 @@ public:
                 consensus.hashGenesisBlock.ToString().c_str(),
                 genesis.hashMerkleRoot.ToString().c_str());
 #else
-        assert(consensus.hashGenesisBlock == uint256S("20ceefa704c19238f71c3435b95aad14919623bbc1b098c93ae0f7d3ee3be071"));
-        assert(genesis.hashMerkleRoot == uint256S("7c27ade2c28e67ed3077f8f77b8ea6d36d4f5eba04c099be3c9faa9a4a04c046"));
+        assert(consensus.hashGenesisBlock == uint256S("7ef0706c82be6448dded7a1bb4d485ab3cd9eab84aaa91aea4d3e5174ab13ca4"));
+        assert(genesis.hashMerkleRoot == uint256S("8183ee6f3edac888efa218dcaae4466574193a34549105cfe22fc78cfba4fa42"));
 #endif
         vFixedSeeds.clear(); //! Regtest mode doesn't have any fixed seeds.
         vSeeds.clear();  //! Regtest mode doesn't have any DNS seeds.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1153,7 +1153,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
 #if 0
         CBlock genesis = chainparams.GenesisBlock();
-        UpdateCvnInfo(&genesis);
+        UpdateCvnInfo(&genesis, 0);
         UpdateChainAdmins(&genesis);
 
         CSchnorrSig chainAdminSig;
@@ -1225,6 +1225,12 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // sanitize comments per BIP-0014, format user agent and check total size
     std::vector<string> uacomments;
+#if 1
+    //TODO: remove this; for development only
+    if (nCvnNodeId) {
+        uacomments.push_back(strprintf("0x%08x", nCvnNodeId));
+    }
+#endif
     BOOST_FOREACH(string cmt, mapMultiArgs["-uacomment"])
     {
         if (cmt != SanitizeString(cmt, SAFE_CHARS_UA_COMMENT))
@@ -1355,7 +1361,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // initialize CVN and chain parameters
     LogPrintf("Initialize CVN and chain parameters\n");
     CBlock genesis = chainparams.GenesisBlock();
-    UpdateCvnInfo(&genesis);
+    UpdateCvnInfo(&genesis, 0);
     UpdateChainParameters(&genesis);
     UpdateChainAdmins(&genesis);
 

--- a/src/main.h
+++ b/src/main.h
@@ -418,7 +418,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex *pindexPrev);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block, with cs_main held) */
-bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
+bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev);
 
 
 class CBlockFileInfo

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1266,7 +1266,7 @@ void ThreadSocketHandler()
                     LogPrintf("socket sending timeout: %is\n", nTime - pnode->nLastSend);
                     pnode->fDisconnect = true;
                 }
-                else if (nTime - pnode->nLastRecv > (pnode->nVersion > BIP0031_VERSION ? TIMEOUT_INTERVAL : 90*60))
+                else if (nTime - pnode->nLastRecv > TIMEOUT_INTERVAL)
                 {
                     LogPrintf("socket receive timeout: %is\n", nTime - pnode->nLastRecv);
                     pnode->fDisconnect = true;

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -49,6 +49,20 @@ uint256 CBlock::GetChainAdminDataHash() const
     return Hash(hashes.begin(), hashes.end());
 }
 
+uint256 CBlock::GetCreatorHash() const
+{
+    CHashWriter ss(SER_GETHASH, nVersion);
+    ss << GetHash() << chainMultiSig;
+
+    if (vMissingSignerIds.size())
+        ss << vMissingSignerIds;
+
+    if (HasAdminPayload())
+        ss << adminMultiSig << vAdminIds;
+
+    return ss.GetHash();
+}
+
 std::string CBlock::ToString() const
 {
     std::stringstream s, payload;
@@ -73,7 +87,7 @@ std::string CBlock::ToString() const
 		vtx.size(), vMissingSignerIds.size());
     if (HasAdminPayload())
     	s << strprintf("  AdminSignature(%u): %s\n", vAdminIds.size(), adminMultiSig.ToString());
-    s << strprintf("  ChainSignature(%u): %s\n", GetNumChainSigs(), chainMultiSig.ToString());
+    s << strprintf("  ChainSignature(%u): %s\n", GetNumChainSigs(this), chainMultiSig.ToString());
     s << "  CreatorSignature: " << creatorSignature.ToString() << "\n";
 
     if (HasCvnInfo())

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -279,7 +279,7 @@ public:
         if (nType & SER_DISK)
             READWRITE(nVersion);
         if ((nType & SER_DISK) ||
-            (nVersion >= CADDR_TIME_VERSION && !(nType & SER_GETHASH)))
+            (nVersion > INIT_PROTO_VERSION && !(nType & SER_GETHASH)))
             READWRITE(nTime);
         READWRITE(nServices);
         READWRITE(*(CService*)this);

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -45,8 +45,6 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("time", (int64_t)blockindex->nTime));
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
     result.push_back(Pair("creator", strprintf("0x%08x", blockindex->nCreatorId)));
-    result.push_back(Pair("signatures", (uint64_t)blockindex->GetNumChainSigs()));
-    result.push_back(Pair("adminSignatures", (uint64_t)blockindex->vAdminIds.size()));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -70,11 +68,12 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, const u
     result.push_back(Pair("version", block.nVersion));
     result.push_back(Pair("payload", blockindex->GetPayloadString()));
     result.push_back(Pair("merkleroot", block.hashMerkleRoot.GetHex()));
+    result.push_back(Pair("hashCreatorSig", block.GetCreatorHash().GetHex()));
     result.push_back(Pair("time", block.GetBlockTime()));
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
     result.push_back(Pair("creator", strprintf("0x%08x", blockindex->nCreatorId)));
     result.push_back(Pair("creatorSignature", block.creatorSignature.ToString()));
-    result.push_back(Pair("nSignatures", (uint64_t)block.GetNumChainSigs()));
+    result.push_back(Pair("nSignatures", (uint64_t)GetNumChainSigs(blockindex)));
     result.push_back(Pair("nAdminSignatures", (uint64_t)block.vAdminIds.size()));
     result.push_back(Pair("chainSignature", block.chainMultiSig.ToString()));
     result.push_back(Pair("adminMultiSig", block.adminMultiSig.IsNull() ? "" : block.adminMultiSig.ToString()));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -198,14 +198,10 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->hashMerkleRoot     = diskindex.hashMerkleRoot;
                 pindexNew->nTime              = diskindex.nTime;
                 pindexNew->nCreatorId         = diskindex.nCreatorId;
-                pindexNew->vMissingCreatorIds = diskindex.vMissingCreatorIds;
-                pindexNew->chainMultiSig      = diskindex.chainMultiSig;
-                pindexNew->vAdminIds          = diskindex.vAdminIds;
-                pindexNew->adminMultiSig      = diskindex.adminMultiSig;
+                pindexNew->vMissingSignerIds  = diskindex.vMissingSignerIds;
                 pindexNew->nStatus            = diskindex.nStatus;
                 pindexNew->nTx                = diskindex.nTx;
 
-                //TODO: put CVN checks here
                 pcursor->Next();
             } else {
                 return error("LoadBlockIndex() : failed to read value");

--- a/src/version.h
+++ b/src/version.h
@@ -9,35 +9,12 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70012;
+static const int PROTOCOL_VERSION = 90200;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
 
-//! In this version, 'getheaders' was introduced.
-static const int GETHEADERS_VERSION = 31800;
-
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = GETHEADERS_VERSION;
-
-//! nTime field added to CAddress, starting with this version;
-//! if possible, avoid requesting addresses nodes older than this
-static const int CADDR_TIME_VERSION = 31402;
-
-//! only request blocks from nodes outside this range of versions
-static const int NOBLKS_VERSION_START = 32000;
-static const int NOBLKS_VERSION_END = 32400;
-
-//! BIP 0031, pong message, is enabled for all versions AFTER this one
-static const int BIP0031_VERSION = 60000;
-
-//! "mempool" command, enhanced "getdata" behavior starts with this version
-static const int MEMPOOL_GD_VERSION = 60002;
-
-//! "filter*" commands are disabled without NODE_BLOOM after and including this version
-static const int NO_BLOOM_VERSION = 70011;
-
-//! "sendheaders" command and announcing blocks with headers starts with this version
-static const int SENDHEADERS_VERSION = 70012;
+static const int MIN_PEER_PROTO_VERSION = 90200;
 
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
…imisations

make blockfactory output less verbose
use cached combined CVN public keys to avoid needlessly combining them
code clean-ups and optimisation
fixed GetNumChainSigs() for CBlock
clean up obsolete protocol version checks
append CVN ID to user agent string for development purpose (to be removed)
fixed option name