### PR TITLE
Add the packaging metadata to build the faircoin snap

### DIFF
--- a/snap/patches/default_data_dir.patch
+++ b/snap/patches/default_data_dir.patch
@@ -1,0 +1,13 @@
+diff --git a/src/util.cpp b/src/util.cpp
+index 57b0419..dd21329 100644
+--- a/src/util.cpp
++++ b/src/util.cpp
+@@ -467,7 +467,7 @@ boost::filesystem::path GetDefaultDataDir()
+     return GetSpecialFolderPath(CSIDL_APPDATA) / "faircoin2";
+ #else
+     fs::path pathRet;
+-    char* pszHome = getenv("HOME");
++    char* pszHome = getenv("SNAP_USER_COMMON");
+     if (pszHome == NULL || strlen(pszHome) == 0)
+         pathRet = fs::path("/");
+     else

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,84 @@
+name: faircoin2
+version: master
+summary: promoting equality and a fair economy
+description: |
+  FairCoin is the monetary base system for FairCoop.
+
+grade: devel
+confinement: strict
+
+apps:
+  daemon:
+    command: faircoind
+    plugs: [network, network-bind]
+    environment:
+      XDG_DATA_DIRS: $SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS
+    aliases: [faircoind]
+  qt:
+    command: desktop-launch bitcoin-qt
+    plugs: [network, network-bind, unity7]
+    aliases: [faircoin-qt]
+  cli:
+    command: faircoin-cli
+    aliases: [faircoin-cli]
+
+parts:
+  faircoin2:
+    source: .
+    source-type: git
+    source-tag: master
+    plugin: autotools
+    configflags: [--disable-tests]
+    # XXX We don't want to copy the full blockchain every time that the snap is
+    # updated, but there's no way to define a default data dir in bitcoin-qt.
+    # Also, it would be better if we could split the wallet from the blockchain
+    # https://github.com/bitcoin/bitcoin/issues/3214
+    # -- elopio-20170308
+    prepare: git apply $SNAPCRAFT_STAGE/default_data_dir.patch
+    build-packages:
+      - g++
+      - pkg-config
+      - libssl-dev
+      - libevent-dev
+      - bsdmainutils
+      # Boost.
+      - libboost-system-dev
+      - libboost-filesystem-dev
+      - libboost-chrono-dev
+      - libboost-program-options-dev
+      - libboost-test-dev
+      - libboost-thread-dev
+      # Optional.
+      - libminiupnpc-dev
+      - libzmq3-dev
+      # GUI.
+      - libqt5gui5
+      - libqt5core5a
+      - libqt5dbus5
+      - qttools5-dev
+      - qttools5-dev-tools
+      - libprotobuf-dev
+      - protobuf-compiler
+      # Optional.
+      - libqrencode-dev
+    stage-packages: [ca-certificates]
+    after:
+      - berkeleydb
+      - desktop-qt5
+      - patches
+  berkeleydb:
+    source: http://download.oracle.com/berkeley-db/db-4.8.30.tar.gz
+    plugin: nil
+    build: |
+      cd build_unix
+      ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$SNAPCRAFT_PART_INSTALL
+    install: |
+      cd build_unix
+      make install
+    prime:
+      - -*
+  patches:
+    source: snap/patches
+    plugin: dump
+    prime:
+      - -*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ apps:
       XDG_DATA_DIRS: $SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS
     aliases: [faircoind]
   qt:
-    command: desktop-launch bitcoin-qt
+    command: desktop-launch faircoin-qt
     plugs: [network, network-bind, unity7]
     aliases: [faircoin-qt]
   cli:


### PR DESCRIPTION
This secure package will let you publish the latest faircoin in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.